### PR TITLE
Refine portfolio styling and content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,13 +3,13 @@
 @import "tailwindcss";
 
 @theme {
-    --color-custom-background: #0F0D0A;
-    --color-custom-foreground: #1C1912;
-    --color-custom-primary: #A98A58;
-    --color-custom-text: #E0CCAB;
-    --color-custom-secondary: #EADCC0;
-    --color-custom-accent: #efeeeb;
-    --color-custom-border: #372B21;
+    --color-custom-background: #0F172A;
+    --color-custom-foreground: #122A39;
+    --color-custom-primary: #5EEAD4;
+    --color-custom-text: #64748B;
+    --color-custom-secondary: #E2E8F0;
+    --color-custom-accent: #003153;
+    --color-custom-border: #64748B;
     --font-custom-alt: "Playfair Display", serif;
     --font-custom: "Lora", serif;
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import Hero from './components/Hero'
 import About from './components/About'
 import Experience from './components/Experience'
+import Projects from './components/Projects'
 import Contact from './components/Contact'
 
 function App() {
@@ -10,9 +11,11 @@ function App() {
       <Hero/>
       <About/>
       <Experience/>
+      <Projects/>
       <Contact/>
     </>
   )
 }
 
 export default App
+

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -27,7 +27,7 @@ const skills = [
 const About = () => {
   return (
     <section className="w-full px-4 sm:px-8 py-12 max-w-4xl mx-auto">
-      <h1 className="text-2xl text-custom-primary mb-8 font-medium">ABOUT ME</h1>
+      <h1 className="text-2xl text-custom-secondary mb-8 font-medium">ABOUT ME</h1>
       <h2 className="text-xl font-semibold text-custom-secondary mb-2">Behind the code</h2>
       <p className="text-base leading-relaxed text-custom-text mb-8">
         Passionate about crafting elegant, efficient solutions to complex problems. I enjoy building APIs, 

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -5,7 +5,7 @@ import { FaTwitter } from "react-icons/fa";
 const ContactSection = () => {
   return (
     <section className="bg-custom-background max-w-4xl mx-auto text-center px-4 sm:px-8 py-12">
-      <h1 className='flex text-2xl text-custom-primary mb-8 font-medium'>CONTACT</h1>
+      <h1 className='flex text-2xl text-custom-secondary mb-8 font-medium'>CONTACT</h1>
         <h2 className="text-4xl font-semibold mb-6 font-custom-alt text-custom-secondary">Get In Touch</h2>
         <p className="text-lg leading-relaxed mb-10">
           I’m always open to new opportunities and would love to hear from you. <br />

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { HiOutlineExternalLink } from 'react-icons/hi';
+import { SiTrimble, SiCapitalone } from 'react-icons/si';
 
 const experiences = [
   {
@@ -7,6 +8,7 @@ const experiences = [
     title: 'Software Engineer',
     company: 'Capital One',
     link: 'https://www.capitalone.com/',
+    icon: SiCapitalone,
     description: `Soon...`,
     tags: ['Excited', ': D', 'New Beginnings'],
   },
@@ -15,6 +17,7 @@ const experiences = [
     title: 'Software Engineer Intern',
     company: 'Trimble',
     link: 'https://www.trimble.com/',
+    icon: SiTrimble,
     description: `Worked on the SketchUp product, specifically on the Extension Warehouse SPA built with Vue.js—fixing bugs, implementing new features, and enhancing functionality, user experience, and SEO.
     Additionally, I developed an AI-powered chatbot using a RAG approach within a serverless architecture to deliver dynamic user recommendations.
     I also contributed to the Desktop Automation team, where I automated tasks using Python to improve development workflow efficiency.
@@ -31,41 +34,42 @@ const experiences = [
 
 const Experience = () => {
   return (
-    <section id="experience" className="bg-custom-background p-6 py-12 max-w-4xl mx-auto">
-      <h2 className="text-2xl font-medium tracking-widest mb-8 text-custom-primary">EXPERIENCE</h2>
-      {experiences.map((exp, idx) => (
-        <div key={idx} className="mb-12">
-          <p className="text-sm font-semibold">{exp.range}</p>
-          <h3 className="text-xl font-bold mt-1 text-custom-secondary flex items-center gap-2">
-            {exp.title} 
-            <span>
-              ·{' '}
-            {exp.company}
-            {' '}
-              <a
-                href={exp.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-custom-primary"
-              >
-                <HiOutlineExternalLink className="w-5 h-5 transition-transform transform hover:scale-110 hover:text-custom-primary hover:drop-shadow-[0_0_5px_rgba(255,215,0,0.5)]" />
-              </a>
-            </span>
-          </h3>
-          {exp.subtitle && <p className="text-custom-primary mt-1">{exp.subtitle}</p>}
-          <p className="mt-2 text-sm leading-relaxed">{exp.description}</p>
-          <div className="flex flex-wrap gap-2 mt-4">
-            {exp.tags.map((tag, i) => (
-              <span
-                key={i}
-                className="bg-custom-foreground border border-custom-border text-xs px-3 py-1 rounded-full"
-              >
-                {tag}
+    <section id="experience" className="bg-custom-background w-full px-4 sm:px-8 py-12 max-w-4xl mx-auto text-custom-text">
+      <h2 className="text-2xl font-medium tracking-widest mb-8 text-custom-secondary">EXPERIENCE</h2>
+      {experiences.map((exp, idx) => {
+        const Icon = exp.icon;
+        return (
+          <div key={idx} className="mb-12">
+            <p className="text-sm font-semibold">{exp.range}</p>
+            <h3 className="text-xl font-bold mt-1 text-custom-secondary flex items-center gap-2">
+              {exp.title}
+              <span className="flex items-center gap-1">
+                · {Icon && <Icon className="w-5 h-5 text-custom-primary" />} {exp.company}
+                <a
+                  href={exp.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-custom-primary"
+                >
+                  <HiOutlineExternalLink className="w-5 h-5 transition-transform transform hover:scale-110 hover:text-custom-primary hover:drop-shadow-[0_0_5px_rgba(255,215,0,0.5)]" />
+                </a>
               </span>
-            ))}
+            </h3>
+            {exp.subtitle && <p className="text-custom-primary mt-1">{exp.subtitle}</p>}
+            <p className="mt-2 text-sm leading-relaxed">{exp.description}</p>
+            <div className="flex flex-wrap gap-2 mt-4">
+              {exp.tags.map((tag, i) => (
+                <span
+                  key={i}
+                  className="bg-custom-foreground border border-custom-border text-custom-primary text-xs px-3 py-1 rounded-full"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </section>
   );
 };

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -5,31 +5,14 @@ import { LuMail } from "react-icons/lu"
 
 const Hero = () => {
   return (
-    <section className="flex flex-col items-center justify-center min-h-screen w-full px-4 bg-custom-background text-custom-primary">
-      <div className="relative flex items-center justify-center mt-6">
-        <div className="absolute w-80 h-80 bg-custom-primary/10 blur-3xl rounded-full z-0 opacity-40" />
-        <div className="relative z-10 w-64 sm:w-80 rounded-xl overflow-hidden 
-          shadow-[0_30px_80px_rgba(0,0,0,0.5)] ring-1 ring-custom-border/10 
-          bg-gradient-to-t from-black/30 via-black/10 to-transparent">
-          <img
-            src="/assets/me.svg"
-            alt="Kevin Payan"
-            className="w-full h-auto object-cover rounded-xl"
-          />
-          <div className="absolute inset-0 rounded-xl 
-            bg-gradient-to-br from-black/15 via-transparent to-black/15 
-            pointer-events-none" />
-          <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-black/70 to-transparent" />
-        </div>
-      </div>
-      <div className="flex flex-col justify-center items-center z-10 font-custom-alt mt-10 text-center">
+    <section className="flex flex-col items-center justify-center min-h-screen w-full px-4 bg-custom-background text-custom-secondary">
+      <div className="flex flex-col justify-center items-center z-10 font-custom-alt text-center">
         <h1 className="text-3xl sm:text-4xl">Hi, I'm</h1>
         <h1 className="text-3xl sm:text-4xl">Kevin Payan</h1>
-        <h2 className="text-xl sm:text-2xl mt-2 text-custom-secondary">I'm a Software Engineer</h2>
+        <h2 className="text-xl sm:text-2xl mt-2 text-custom-text">I'm a Software Engineer</h2>
       </div>
       <button
-        className="mt-6 bg-custom-primary text-custom-accent font-medium px-6 py-2 rounded transition-all duration-300
-          focus:outline-none focus:ring-2 focus:ring-custom-primary/40"
+        className="mt-6 bg-custom-primary text-custom-accent font-medium px-6 py-2 rounded transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-custom-primary/40"
         onClick={() =>
           document.getElementById('experience').scrollIntoView({ behavior: 'smooth' })
         }

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const Projects = () => {
+  return (
+    <section id="projects" className="bg-custom-background w-full px-4 sm:px-8 py-12 max-w-4xl mx-auto text-custom-text">
+      <h2 className="text-2xl font-medium tracking-widest mb-8 text-custom-secondary">PROJECTS</h2>
+      <div className="mb-12">
+        <h3 className="text-xl font-bold mt-1 text-custom-secondary">HuellitasApp</h3>
+        <p className="mt-2 text-sm leading-relaxed">
+          A cross-platform mobile booking app for dog walking services. Built with React Native and ASP.NET Core, it enables pet owners to schedule walks, make secure payments via Stripe, and locate walkers using Google Maps. Hosted on Azure, the app is designed for deployment on both iOS and Android from a single codebase. Focused on streamlined booking rather than real-time ride matching.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default Projects
+

--- a/src/components/SkillTag.jsx
+++ b/src/components/SkillTag.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 
-const SkillTag = ({ icon: Icon, label }) => {
+const SkillTag = ({ icon, label }) => {
+  const Icon = icon
   return (
-    <div className="flex items-center justify-center gap-2 px-4 py-2 rounded-full bg-custom-foreground text-lg font-medium border border-custom-border">
-      <Icon className="w-6 h-6 text-custom-primary" />
+    <div className="flex items-center justify-center gap-2 px-4 py-2 rounded-full bg-custom-foreground text-custom-primary text-lg font-medium border border-custom-border">
+      <Icon className="w-6 h-6" />
       <span>{label}</span>
     </div>
   )


### PR DESCRIPTION
## Summary
- adopt new blue and teal color palette across the site
- add company icons and responsive project section
- streamline hero section by removing portrait

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eace63cd883248d16596a4519f23f